### PR TITLE
compat: Allow Aqua 0.8

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -10,9 +10,11 @@ Logging = "56ddb016-857b-54e1-b83d-db4d58db5568"
 TimerOutputs = "a759f4b9-e2f1-59dc-863e-4aeb61b1ea8f"
 
 [compat]
-Aqua = "0.6"
+Aqua = "0.6, 0.8"
 DataStructures = "0.18, 0.19"
 DocStringExtensions = "0.9"
+Logging = "1"
+Test = "1"
 TimerOutputs = "0.5"
 julia = "1"
 


### PR DESCRIPTION
Aqua 0.6.x's type-piracy/ambiguity detection produces false positives under JuliaLang/julia#61915 (the TypeEq refactor): Type{T} is now a TypeEq kind, so the package's own inner constructors are mis-flagged as piracy. Aqua 0.8.15 fixes this. Allow Aqua 0.8 and add the [compat]/API adjustments required by Aqua 0.8 so the test suite passes on recent Julia.

This change was made with the assistance of generative AI (Claude Code).